### PR TITLE
Security fixes: XSS, Open Redirect, CORS, XXE, Error Message Exposure

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,41 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.25.1
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  SNYK-PHP-SIMPLEXML-XXE:
+    - '*':
+        reason: >-
+          Project requires PHP 8.2+ (see CLAUDE.md and composer.json). PHP 8.0+
+          disables external entity loading by default in libxml2. Additionally,
+          LIBXML_NONET flag is used to disable network access. These findings
+          are marked as "Pre-PHP 8" by Snyk itself.
+        expires: 2027-01-08T00:00:00.000Z
+  565116bf-4829-4819-aaca-fe98f5ba3d84:
+    - '*':
+        reason: >-
+          Project requires PHP 8.2+ where external entities are disabled by
+          default
+        expires: 2026-02-07T21:34:28.313Z
+        created: 2026-01-08T21:34:28.316Z
+  b08940ad-e61c-4867-b544-7023b6a29d72:
+    - '*':
+        reason: >-
+          Project requires PHP 8.2+ where external entities are disabled by
+          default
+        expires: 2026-02-07T21:34:37.981Z
+        created: 2026-01-08T21:34:37.984Z
+  8045f3ba-8bbe-4de9-abbb-0080df764269:
+    - '*':
+        reason: >-
+          Project requires PHP 8.2+ where external entities are disabled by
+          default
+        expires: 2026-02-07T21:34:46.021Z
+        created: 2026-01-08T21:34:46.025Z
+  75d78668-d12d-4191-a08f-b88a37000e1b:
+    - '*':
+        reason: >-
+          Comprehensive URL validation with whitelist and fallback to safe
+          default
+        expires: 2026-02-07T21:34:54.569Z
+        created: 2026-01-08T21:34:54.573Z
+patch: {}

--- a/src/gadgetapi.php
+++ b/src/gadgetapi.php
@@ -5,8 +5,19 @@ declare(strict_types=1);
 // https://en.wikipedia.org/wiki/MediaWiki:Gadget-citations.js
 set_time_limit(120);
 
+// Validate origin for CORS - allow Wikipedia/Wikimedia domains and toolforge
+$origin = $_SERVER['HTTP_ORIGIN'] ?? '';
+$allowed_origin = '';
+if (preg_match('~^https://[a-z\-]+\.(wikipedia|wikimedia|wikibooks|wikisource|wikinews|wikiquote|wiktionary|wikiversity|wikivoyage|wikidata|mediawiki)\.org$~', $origin)) {
+    $allowed_origin = $origin;
+} elseif (preg_match('~^https://[a-z\-]+\.toolforge\.org$~', $origin)) {
+    $allowed_origin = $origin;
+}
+
 try {
-    @header('Access-Control-Allow-Origin: *'); // Needed for gadget to work right
+    if ($allowed_origin !== '') {
+        @header('Access-Control-Allow-Origin: ' . $allowed_origin);
+    }
     @header('Content-Type: text/json');
 
     //Set up tool requirements

--- a/src/includes/WikipediaBot.php
+++ b/src/includes/WikipediaBot.php
@@ -171,8 +171,8 @@ final class WikipediaBot {
             return self::ret_okay($ret) ? $ret : null;
             // @codeCoverageIgnoreStart
         } catch (Exception $E) {
-            report_warning("Exception caught!\n");
-            report_info("Response: " . echoable($E->getMessage()));
+            bot_debug_log("WikipediaBot fetch exception: " . $E->getMessage());
+            report_warning("Exception caught during Wikipedia API request");
         }
         return null;
         // @codeCoverageIgnoreEnd
@@ -423,8 +423,8 @@ final class WikipediaBot {
             return self::ret_okay(@json_decode($data)) ? $data : '';
             // @codeCoverageIgnoreStart
         } catch (Exception $E) {
-            report_warning("Exception caught!!\n");
-            report_info("Response: " . echoable($E->getMessage()));
+            bot_debug_log("WikipediaBot QueryAPI exception: " . $E->getMessage());
+            report_warning("Exception caught during Wikipedia API query");
         }
         return '';
         // @codeCoverageIgnoreEnd
@@ -553,7 +553,7 @@ final class WikipediaBot {
             $return = $_SERVER['REQUEST_URI'];
             unset($_SERVER['REQUEST_URI']);
             session_write_close();
-            if (mb_substr($return, 0, 1) !== '/' || preg_match('~\s+~', $return)) { // Security paranoia
+            if (mb_substr($return, 0, 1) !== '/' || mb_substr($return, 0, 2) === '//' || preg_match('~\s+~', $return)) { // Security paranoia
                 report_error('Invalid URL passes to internal API');
             }
             /** @psalm-taint-escape header */

--- a/src/includes/api/APIBibCode.php
+++ b/src/includes/api/APIBibCode.php
@@ -444,7 +444,7 @@ function adsabs_api(array $ids, array &$templates, string $identifier): void {  
                 }
             } else {
                 bot_debug_log("No match for bibcode identifier: " . $bad_boy);
-                report_warning("No match for bibcode identifier: " . $bad_boy);
+                report_warning("No match for bibcode identifier: " . echoable($bad_boy));
             }
         }
 
@@ -597,16 +597,17 @@ function Bibcode_Response_Processing(array $curl_opts, string $adsabs_url): obje
         }
         // @codeCoverageIgnoreStart
     } catch (Exception $e) {
+        bot_debug_log("query_adsabs exception: " . $e->getMessage());
         if ($e->getCode() === 5000) { // made up code for AdsAbs error
-            report_warning(sprintf("API Error in query_adsabs: %s", echoable($e->getMessage())));
+            report_warning("API Error in query_adsabs: AdsAbs returned an error response");
         } elseif ($e->getCode() === 60) {
             AdsAbsControl::big_give_up();
             AdsAbsControl::small_give_up();
             report_warning('Giving up on AdsAbs for a while.  SSL certificate has expired.');
         } elseif (mb_strpos($e->getMessage(), 'org.apache.solr.search.SyntaxError') !== false) {
-            report_info(sprintf("Internal Error %d in query_adsabs: %s", $e->getCode(), echoable($e->getMessage())));
+            report_info("Internal Error in query_adsabs: Search syntax error");
         } elseif (mb_strpos($e->getMessage(), 'HTTP') === 0) {
-            report_warning(sprintf("HTTP Error %d in query_adsabs: %s", $e->getCode(), echoable($e->getMessage())));
+            report_warning("HTTP Error in query_adsabs");
         } elseif (mb_strpos($e->getMessage(), 'Too many requests') !== false) {
             report_warning('Giving up on AdsAbs for a while.  Too many requests.');
             if (mb_strpos($adsabs_url, 'bigquery') !== false) {
@@ -615,7 +616,7 @@ function Bibcode_Response_Processing(array $curl_opts, string $adsabs_url): obje
                 AdsAbsControl::small_give_up();
             }
         } else {
-            report_warning(sprintf("Error %d in query_adsabs: %s", $e->getCode(), echoable($e->getMessage())));
+            report_warning("Error in query_adsabs: An unexpected error occurred");
         }
     }
     return (object) ['numFound' => 0];

--- a/src/includes/api/APIPubMed.php
+++ b/src/includes/api/APIPubMed.php
@@ -189,7 +189,7 @@ function xml_post(string $url, string $post): ?SimpleXMLElement {
         CURLOPT_POSTFIELDS => $post,
     ]);
     $output = bot_curl_exec($ch);
-    $xml = @simplexml_load_string($output);
+    $xml = @simplexml_load_string($output, SimpleXMLElement::class, LIBXML_NONET);
     if ($xml === false) {
         sleep(1);
         return null;

--- a/src/includes/api/APIdoi.php
+++ b/src/includes/api/APIdoi.php
@@ -230,7 +230,7 @@ function query_crossref(string $doi): ?object {
             '~(\<year media_type=\"online\"\>\d{4}\<\/year\>\<year media_type=\"print\"\>)~',
                     '<year media_type="print">',
                     $raw_xml);
-        $xml = @simplexml_load_string($raw_xml);
+        $xml = @simplexml_load_string($raw_xml, SimpleXMLElement::class, LIBXML_NONET);
         unset($raw_xml);
         if (is_object($xml) && isset($xml->query_result->body->query)) {
             $result = $xml->query_result->body->query;
@@ -578,7 +578,7 @@ function get_doi_from_crossref(Template $template): void {
         curl_setopt($ch, CURLOPT_URL, $url);
         $xml = bot_curl_exec($ch);
         if (mb_strlen($xml) > 0) {
-            $result = @simplexml_load_string($xml);
+            $result = @simplexml_load_string($xml, SimpleXMLElement::class, LIBXML_NONET);
             unset($xml);
         } else {
             $result = false;

--- a/src/includes/api/APIgoogle.php
+++ b/src/includes/api/APIgoogle.php
@@ -209,7 +209,7 @@ function google_book_details(Template $template, string $gid): void {
         return;
     }
     $simplified_xml = str_replace('http___//www.w3.org/2005/Atom', 'http://www.w3.org/2005/Atom', str_replace(":", "___", $data));
-    $xml = @simplexml_load_string($simplified_xml);
+    $xml = @simplexml_load_string($simplified_xml, SimpleXMLElement::class, LIBXML_NONET);
     if ($xml === false) {
         return;
     }

--- a/src/includes/user_messages.php
+++ b/src/includes/user_messages.php
@@ -107,7 +107,8 @@ function echoable(?string $string): string {
      * @psalm-taint-escape has_quotes
      */
     $string = (string) $string;
-     return HTML_OUTPUT ? htmlspecialchars($string, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401) : $string;
+    // Always sanitize to prevent XSS in all output modes
+    return htmlspecialchars($string, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401);
 }
 
 function pubmed_link(string $identifier, string $pm): string {


### PR DESCRIPTION
## Summary

Security fixes addressing 24 issues identified by Snyk code analysis, reduced to 4 accepted findings (3 LOW, 1 MEDIUM).

### Fixed Issues

- **XSS (20 issues)** - Modified `echoable()` to always sanitize with `htmlspecialchars()` regardless of output mode
- **Open Redirect** - Added comprehensive URL validation in `authenticate.php` with whitelist (relative paths, trusted Wikimedia domains) and safe fallback
- **CORS** - Changed `Access-Control-Allow-Origin` from `*` to validated Wikimedia/toolforge.org domains only in `gadgetapi.php`
- **XXE Protection** - Added `LIBXML_NONET` flag to all `simplexml_load_string()` calls
- **Server Error Message Exposure (6 issues)** - Removed exception details from user-visible output, now logged via `bot_debug_log()` instead

### Files Modified

- `src/authenticate.php` - Open redirect fix with whitelist validation
- `src/gadgetapi.php` - CORS restricted to Wikimedia domains
- `src/includes/WikipediaBot.php` - Error message sanitization, redirect fix
- `src/includes/api/APIBibCode.php` - XSS fix, error message sanitization
- `src/includes/api/APIPubMed.php` - LIBXML_NONET added
- `src/includes/api/APIdoi.php` - LIBXML_NONET added
- `src/includes/api/APIgoogle.php` - LIBXML_NONET added
- `src/includes/user_messages.php` - `echoable()` always sanitizes
- `.snyk` - Policy file documenting accepted findings

### Accepted Findings (documented in .snyk)

- 3 LOW XXE "Pre-PHP 8" - Project requires PHP 8.2+ where external entities are disabled by default
- 1 MEDIUM Open Redirect - Has comprehensive validation that Snyk static analysis does not recognize

## Test plan

- [ ] Verify OAuth authentication flow still works
- [ ] Verify gadget API responds to requests from Wikipedia domains
- [ ] Verify bibcode, DOI, PubMed, and Google Books lookups still function
- [ ] Run existing PHPUnit tests