### PR TITLE
Fix false 'Save to file failed' warning in savetofiles mode

### DIFF
--- a/src/includes/WebTools.php
+++ b/src/includes/WebTools.php
@@ -44,7 +44,7 @@ function edit_a_list_of_pages(array $pages_in_category, WikipediaBot $api, strin
                 $filename = preg_replace('~[\/\\:*?"<>|\s]~', '_', $page_title) . '.md';
                 report_phase("Saving to file " . echoable($filename));
                 $body = $page->parsed_text();
-                $bodylen = strlen($body);
+                $bodylen = mb_strlen($body, '8bit'); // byte count, not character count
                 if (file_put_contents($filename, $body) === $bodylen) {
                     report_phase("Saved to file " . echoable($filename));
                 } else {

--- a/src/includes/WebTools.php
+++ b/src/includes/WebTools.php
@@ -44,7 +44,7 @@ function edit_a_list_of_pages(array $pages_in_category, WikipediaBot $api, strin
                 $filename = preg_replace('~[\/\\:*?"<>|\s]~', '_', $page_title) . '.md';
                 report_phase("Saving to file " . echoable($filename));
                 $body = $page->parsed_text();
-                $bodylen = mb_strlen($body);
+                $bodylen = strlen($body);
                 if (file_put_contents($filename, $body) === $bodylen) {
                     report_phase("Saved to file " . echoable($filename));
                 } else {


### PR DESCRIPTION
## Summary

- `file_put_contents()` returns the number of **bytes** written, but the code compared it against `mb_strlen()` which returns **character** count. For any article with multi-byte UTF-8 characters, bytes > characters, so the check always failed -- showing "Save to file failed" even though the file was saved correctly.
- Fix: use `strlen()` (byte count) instead of `mb_strlen()` (character count).

## Test plan

- Run `php process_page.php "Ketotifen" --slow --savetofiles` on an article with multi-byte characters and confirm the warning no longer appears.